### PR TITLE
docs: removed SPDX header from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
 name: Feature request
 about: Suggest an idea for this project


### PR DESCRIPTION
Removed the header since it is suspected of interrupting the template automation.